### PR TITLE
Fix v-model not working on input

### DIFF
--- a/src/components/BccInput/BccInput.vue
+++ b/src/components/BccInput/BccInput.vue
@@ -9,6 +9,7 @@ import { computed, type StyleValue } from "vue";
 import { useAttrs } from "vue";
 
 type Props = {
+  modelValue?: string;
   state?: "default" | "error" | "success";
   disabled?: boolean;
   label?: string;
@@ -24,6 +25,8 @@ const props = withDefaults(defineProps<Props>(), {
   showOptionalLabel: false,
   optionalLabel: "Optional",
 });
+
+defineEmits(["update:modelValue"]);
 
 const showOptionalLabel = computed(() => props.showOptionalLabel && !props.required);
 
@@ -65,6 +68,8 @@ const attrsWithoutStyles = computed(() => {
           'bcc-input-error': state === 'error',
           'bcc-input-success': state === 'success',
         }"
+        :value="modelValue"
+        @input="$emit('update:modelValue', ($event.target as HTMLInputElement).value)"
         v-bind="attrsWithoutStyles"
       />
     </label>


### PR DESCRIPTION
On components `v-model` expands into using `:modelValue`: https://vuejs.org/guide/components/v-model.html#component-v-model

We still do a `v-bind` of all attributes so binding a `value` property should still work - it's just not reactive.

Fixes #94 